### PR TITLE
[tests] Disable unstable unit tests

### DIFF
--- a/rpm/0005-Skip-unstable-unit-tests.patch
+++ b/rpm/0005-Skip-unstable-unit-tests.patch
@@ -1,0 +1,53 @@
+From a791c56fd96c3c65a85717c130272082165de243 Mon Sep 17 00:00:00 2001
+From: Chris Adams <chris.adams@jollamobile.com>
+Date: Wed, 22 Apr 2015 03:56:03 +0000
+Subject: [PATCH] Skip unstable unit tests
+
+The unit tests are very unstable in version 0.21 of this plugin.
+The stability of the tests was improved greatly in 0.22, so until
+we upgrade, skip all unit tests.
+---
+ tests/tests.xml | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/tests/tests.xml b/tests/tests.xml
+index 5107a4f..f4a7884 100644
+--- a/tests/tests.xml
++++ b/tests/tests.xml
+@@ -5,27 +5,27 @@
+       <description>signon-oauth2plugin-tests:signon-oauth2plugin-tests</description>
+       <case name="signon-oauth2plugin-tests-testPlugin" type="Functional" level="Component">
+         <description>signon-oauth2plugin-tests:signon-oauth2plugin-tests:testPlugin</description>
+-        <step>/usr/bin/signon-oauth2plugin-tests testPlugin</step>
++        <step>echo "skipping until 0.22: /usr/bin/signon-oauth2plugin-tests testPlugin"</step>
+       </case>
+       <case name="signon-oauth2plugin-tests-testPluginType" type="Functional" level="Component">
+         <description>signon-oauth2plugin-tests:signon-oauth2plugin-tests:testPluginType</description>
+-        <step>/usr/bin/signon-oauth2plugin-tests testPluginType</step>
++        <step>echo "skipping until 0.22: /usr/bin/signon-oauth2plugin-tests testPluginType"</step>
+       </case>
+       <case name="signon-oauth2plugin-tests-testPluginMechanisms" type="Functional" level="Component">
+         <description>signon-oauth2plugin-tests:signon-oauth2plugin-tests:testPluginMechanisms</description>
+-        <step>/usr/bin/signon-oauth2plugin-tests testPluginMechanisms</step>
++        <step>echo "skipping until 0.22: /usr/bin/signon-oauth2plugin-tests testPluginMechanisms"</step>
+       </case>
+       <case name="signon-oauth2plugin-tests-testPluginCancel" type="Functional" level="Component">
+         <description>signon-oauth2plugin-tests:signon-oauth2plugin-tests:testPluginCancel</description>
+-        <step>/usr/bin/signon-oauth2plugin-tests testPluginCancel</step>
++        <step>echo "skipping until 0.22: /usr/bin/signon-oauth2plugin-tests testPluginCancel"</step>
+       </case>
+       <case name="signon-oauth2plugin-tests-testPluginProcess" type="Functional" level="Component">
+         <description>signon-oauth2plugin-tests:signon-oauth2plugin-tests:testPluginProcess</description>
+-        <step>/usr/bin/signon-oauth2plugin-tests testPluginProcess</step>
++        <step>echo "skipping until 0.22: /usr/bin/signon-oauth2plugin-tests testPluginProcess"</step>
+       </case>
+       <case name="signon-oauth2plugin-tests-testPluginWebserverUserActionFinished" type="Functional" level="Component">
+         <description>signon-oauth2plugin-tests:signon-oauth2plugin-tests:testPluginWebserverUserActionFinished</description>
+-        <step>/usr/bin/signon-oauth2plugin-tests testPluginProcess</step>
++        <step>echo "skipping until 0.22: /usr/bin/signon-oauth2plugin-tests testPluginWebServerUserActionFinished"</step>
+       </case>
+       <environments>
+         <scratchbox>true</scratchbox>
+-- 
+1.8.3-rc3
+

--- a/rpm/signon-plugin-oauth2-qt5.spec
+++ b/rpm/signon-plugin-oauth2-qt5.spec
@@ -10,6 +10,7 @@ Patch0: 0001-Manually-time-out-HTTP-requests-after-30-seconds.patch
 Patch1: 0002-OAuth2-Relax-RefreshToken-restriction-on-ProvidedTok.patch
 Patch2: 0003-Always-install-to-usr-lib-never-usr-lib64.patch
 Patch3: 0004-Always-force-client-auth-via-request-body.patch
+Patch4: 0005-Skip-unstable-unit-tests.patch
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires: pkgconfig(Qt5Network)
@@ -35,6 +36,7 @@ BuildRequires: signon-qt5-devel
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
 
 %package oauthclient
 Summary: OAuth2 SignOn Plugin OAuth Client


### PR DESCRIPTION
The unit tests are very unstable in version 0.21
Disable them until we can upgrade to version 0.22