### PR TITLE
Fix dropbox authentication by removing "type" query argument

### DIFF
--- a/rpm/0006-Remove-type-query-argument-for-dropbox.patch
+++ b/rpm/0006-Remove-type-query-argument-for-dropbox.patch
@@ -1,0 +1,12 @@
+--- a/src/oauth2plugin.cpp
++++ b/src/oauth2plugin.cpp
+@@ -140,7 +140,9 @@ void OAuth2Plugin::sendOAuth2AuthRequest()
+     if (!d->m_oauth2Data.Display().isEmpty()) {
+         url.addQueryItem(DISPLAY, d->m_oauth2Data.Display());
+     }
+-    url.addQueryItem(QString("type"), d->m_mechanism);
++    if (!((d->m_oauth2Data.Host().contains(QLatin1String("dropbox.com")))
++          || (d->m_oauth2Data.Host().contains(QLatin1String("dropboxapi.com")))))
++        url.addQueryItem(QString("type"), d->m_mechanism);
+     if (!d->m_oauth2Data.Scope().empty()) {
+         QString separator = QLatin1String(" ");

--- a/rpm/signon-plugin-oauth2-qt5.spec
+++ b/rpm/signon-plugin-oauth2-qt5.spec
@@ -11,6 +11,7 @@ Patch1: 0002-OAuth2-Relax-RefreshToken-restriction-on-ProvidedTok.patch
 Patch2: 0003-Always-install-to-usr-lib-never-usr-lib64.patch
 Patch3: 0004-Always-force-client-auth-via-request-body.patch
 Patch4: 0005-Skip-unstable-unit-tests.patch
+Patch5: 0006-Remove-type-query-argument-for-dropbox.patch
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires: pkgconfig(Qt5Network)
@@ -37,6 +38,7 @@ BuildRequires: signon-qt5-devel
 %patch2 -p1
 %patch3 -p1
 %patch4 -p1
+%patch5 -p1
 
 %package oauthclient
 Summary: OAuth2 SignOn Plugin OAuth Client


### PR DESCRIPTION
Fixes https://code.google.com/p/accounts-sso/issues/detail?id=245
Based on https://gitlab.com/accounts-sso/signon-plugin-oauth2/commit/1175309c672192380b7161b175b5268135209af8 (adapted to be dropbox specific)
Built at https://build.merproject.org/package/binaries/home:filippz/signon-plugin-oauth2-qt5?repository=Mer_Core_armv7hl
Tested with Google and Dropbox accounts
